### PR TITLE
Add LDFLAGS

### DIFF
--- a/lattice.go
+++ b/lattice.go
@@ -1,5 +1,6 @@
 package mecab
 
+// #cgo LDFLAGS: -lmecab
 // #include <mecab.h>
 // #include <stdlib.h>
 import "C"

--- a/mecab.go
+++ b/mecab.go
@@ -1,5 +1,6 @@
 package mecab
 
+// #cgo LDFLAGS: -lmecab
 // #include <mecab.h>
 // #include <stdlib.h>
 import "C"

--- a/model.go
+++ b/model.go
@@ -1,5 +1,6 @@
 package mecab
 
+// #cgo LDFLAGS: -lmecab
 // #include <mecab.h>
 // #include <stdlib.h>
 import "C"

--- a/node.go
+++ b/node.go
@@ -1,5 +1,6 @@
 package mecab
 
+// #cgo LDFLAGS: -lmecab
 // #include <mecab.h>
 // #include <stdlib.h>
 import "C"


### PR DESCRIPTION
In my environment (CentOS 7.3.1611, go 1.8, MeCab 0.996), `go-mecab` claims MeCab library is not found as below.
ref: http://stackoverflow.com/questions/29438761/cgo-undefined-reference-in-included-files

Please consider. :bow:

```
$ go test
# _/home/***/src/go-mecab
/tmp/go-build553793416/_/home/***/src/go-mecab/_test/_obj_test/lattice.cgo2.o: In function `_cgo_2412c6cfb566_Cfunc_mecab_lattice_get_bos_node':
./cgo-gcc-prolog:78: undefined reference to `mecab_lattice_get_bos_node'
/tmp/go-build553793416/_/home/***/src/go-mecab/_test/_obj_test/lattice.cgo2.o: In function `_cgo_2412c6cfb566_Cfunc_mecab_lattice_get_eos_node':
./cgo-gcc-prolog:95: undefined reference to `mecab_lattice_get_eos_node'
/tmp/go-build553793416/_/home/***/src/go-mecab/_test/_obj_test/lattice.cgo2.o: In function `_cgo_2412c6cfb566_Cfunc_mecab_lattice_get_sentence':
./cgo-gcc-prolog:112: undefined reference to `mecab_lattice_get_sentence'
/tmp/go-build553793416/_/home/***/src/go-mecab/_test/_obj_test/lattice.cgo2.o: In function `_cgo_2412c6cfb566_Cfunc_mecab_lattice_is_available':
./cgo-gcc-prolog:130: undefined reference to `mecab_lattice_is_available'
/tmp/go-build553793416/_/home/***/src/go-mecab/_test/_obj_test/lattice.cgo2.o: In function `_cgo_2412c6cfb566_Cfunc_mecab_lattice_new':
./cgo-gcc-prolog:146: undefined reference to `mecab_lattice_new'
/tmp/go-build553793416/_/home/***/src/go-mecab/_test/_obj_test/lattice.cgo2.o: In function `_cgo_2412c6cfb566_Cfunc_mecab_lattice_tostr':
./cgo-gcc-prolog:177: undefined reference to `mecab_lattice_tostr'
/tmp/go-build553793416/_/home/***/src/go-mecab/_test/_obj_test/lattice.cgo2.o: In function `_cgo_2412c6cfb566_Cfunc_mecab_lattice_add_request_type':
./cgo-gcc-prolog:39: undefined reference to `mecab_lattice_add_request_type'
/tmp/go-build553793416/_/home/***/src/go-mecab/_test/_obj_test/lattice.cgo2.o: In function `_cgo_2412c6cfb566_Cfunc_mecab_lattice_clear':
./cgo-gcc-prolog:51: undefined reference to `mecab_lattice_clear'
/tmp/go-build553793416/_/home/***/src/go-mecab/_test/_obj_test/lattice.cgo2.o: In function `_cgo_2412c6cfb566_Cfunc_mecab_lattice_destroy':
./cgo-gcc-prolog:63: undefined reference to `mecab_lattice_destroy'
/tmp/go-build553793416/_/home/***/src/go-mecab/_test/_obj_test/lattice.cgo2.o: In function `_cgo_2412c6cfb566_Cfunc_mecab_lattice_set_sentence2':
./cgo-gcc-prolog:162: undefined reference to `mecab_lattice_set_sentence2'
/tmp/go-build553793416/_/home/***/src/go-mecab/_test/_obj_test/mecab.cgo2.o: In function `_cgo_2412c6cfb566_Cfunc_mecab_new':
./cgo-gcc-prolog:66: undefined reference to `mecab_new'
/tmp/go-build553793416/_/home/***/src/go-mecab/_test/_obj_test/mecab.cgo2.o: In function `_cgo_2412c6cfb566_Cfunc_mecab_parse_lattice':
./cgo-gcc-prolog:85: undefined reference to `mecab_parse_lattice'
/tmp/go-build553793416/_/home/***/src/go-mecab/_test/_obj_test/mecab.cgo2.o: In function `_cgo_2412c6cfb566_Cfunc_mecab_sparse_tonode2':
./cgo-gcc-prolog:104: undefined reference to `mecab_sparse_tonode2'
/tmp/go-build553793416/_/home/***/src/go-mecab/_test/_obj_test/mecab.cgo2.o: In function `_cgo_2412c6cfb566_Cfunc_mecab_sparse_tostr2':
./cgo-gcc-prolog:123: undefined reference to `mecab_sparse_tostr2'
/tmp/go-build553793416/_/home/***/src/go-mecab/_test/_obj_test/mecab.cgo2.o: In function `_cgo_2412c6cfb566_Cfunc_mecab_strerror':
./cgo-gcc-prolog:140: undefined reference to `mecab_strerror'
/tmp/go-build553793416/_/home/***/src/go-mecab/_test/_obj_test/mecab.cgo2.o: In function `_cgo_2412c6cfb566_Cfunc_mecab_destroy':
./cgo-gcc-prolog:49: undefined reference to `mecab_destroy'
/tmp/go-build553793416/_/home/***/src/go-mecab/_test/_obj_test/model.cgo2.o: In function `_cgo_2412c6cfb566_Cfunc_mecab_model_new':
./cgo-gcc-prolog:54: undefined reference to `mecab_model_new'
/tmp/go-build553793416/_/home/***/src/go-mecab/_test/_obj_test/model.cgo2.o: In function `_cgo_2412c6cfb566_Cfunc_mecab_model_new_lattice':
./cgo-gcc-prolog:71: undefined reference to `mecab_model_new_lattice'
/tmp/go-build553793416/_/home/***/src/go-mecab/_test/_obj_test/model.cgo2.o: In function `_cgo_2412c6cfb566_Cfunc_mecab_model_new_tagger':
./cgo-gcc-prolog:88: undefined reference to `mecab_model_new_tagger'
/tmp/go-build553793416/_/home/***/src/go-mecab/_test/_obj_test/model.cgo2.o: In function `_cgo_2412c6cfb566_Cfunc_mecab_model_swap':
./cgo-gcc-prolog:107: undefined reference to `mecab_model_swap'
/tmp/go-build553793416/_/home/***/src/go-mecab/_test/_obj_test/model.cgo2.o: In function `_cgo_2412c6cfb566_Cfunc_mecab_model_destroy':
./cgo-gcc-prolog:37: undefined reference to `mecab_model_destroy'
collect2: error: ld returned 1 exit status
FAIL    _/home/***/src/go-mecab [build failed]
```