### PR TITLE
GitHub Actions: Deprecating set-env and add-path commands

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,10 +23,10 @@ jobs:
       - name: install mecab
         run: |
           .github/install-mecab-linux.sh
-          echo "::set-env name=CGO_LDFLAGS::$(mecab-config --libs)"
-          echo "::set-env name=CGO_CFLAGS::-I$(mecab-config --inc-dir)"
+          echo "CGO_LDFLAGS=$(mecab-config --libs)" >> "$GITHUB_ENV"
+          echo "CGO_CFLAGS=-I$(mecab-config --inc-dir)" >> "$GITHUB_ENV"
       - name: setup Go ${{ matrix.go }}
-        uses: actions/setup-go@v1
+        uses: actions/setup-go@v2
         with:
           go-version: ${{ matrix.go }}
       - name: test
@@ -50,10 +50,10 @@ jobs:
       - name: install mecab
         run: |
           .github/install-mecab-darwin.sh
-          echo "::set-env name=CGO_LDFLAGS::$(mecab-config --libs)"
-          echo "::set-env name=CGO_CFLAGS::-I$(mecab-config --inc-dir)"
+          echo "CGO_LDFLAGS=$(mecab-config --libs)" >> "$GITHUB_ENV"
+          echo "CGO_CFLAGS=-I$(mecab-config --inc-dir)" >> "$GITHUB_ENV"
       - name: setup Go ${{ matrix.go }}
-        uses: actions/setup-go@v1
+        uses: actions/setup-go@v2
         with:
           go-version: ${{ matrix.go }}
       - name: test


### PR DESCRIPTION
ref. https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/

and some improvements of GitHub Actions Workflow.