### PR TITLE
clear the finalizer in Destroy

### DIFF
--- a/lattice.go
+++ b/lattice.go
@@ -54,9 +54,9 @@ func NewLattice() (Lattice, error) {
 
 // Destroy frees the lattice.
 func (l Lattice) Destroy() {
+	runtime.SetFinalizer(l.l, nil) // clear the finalizer
 	C.mecab_lattice_destroy(l.l.lattice)
 	l.l.lattice = nil
-	runtime.KeepAlive(l.l)
 }
 
 // Clear set empty string to the lattice.

--- a/lattice_test.go
+++ b/lattice_test.go
@@ -1,0 +1,15 @@
+package mecab
+
+import (
+	"runtime"
+	"testing"
+)
+
+func TestLatticeFinalizer(t *testing.T) {
+	for i := 0; i < 10000; i++ {
+		NewLattice()
+	}
+	runtime.GC()
+	runtime.GC()
+	runtime.GC()
+}

--- a/mecab.go
+++ b/mecab.go
@@ -81,6 +81,7 @@ func New(args map[string]string) (MeCab, error) {
 
 // Destroy frees the MeCab parser.
 func (m MeCab) Destroy() {
+	runtime.SetFinalizer(m.m, nil) // clear the finalizer
 	C.mecab_destroy(m.m.mecab)
 	m.m.mecab = nil
 }

--- a/mecab_test.go
+++ b/mecab_test.go
@@ -2,6 +2,7 @@ package mecab
 
 import (
 	"os"
+	"runtime"
 	"strings"
 	"testing"
 )
@@ -150,6 +151,15 @@ func TestParseToNode(t *testing.T) {
 	if node.Surface() != "世界" {
 		t.Errorf("want 世界, but %s", node.Surface())
 	}
+}
+
+func TestMeCabFinalizer(t *testing.T) {
+	for i := 0; i < 10000; i++ {
+		New(rcfile(map[string]string{}))
+	}
+	runtime.GC()
+	runtime.GC()
+	runtime.GC()
 }
 
 func BenchmarkParseToNode(b *testing.B) {

--- a/mecab_test.go
+++ b/mecab_test.go
@@ -160,7 +160,7 @@ func BenchmarkParseToNode(b *testing.B) {
 	mecab.Parse("")
 
 	for i := 0; i < b.N; i++ {
-		for node, _ := mecab.ParseToNode("こんにちは世界"); node != (Node{}); node = node.Next() {
+		for node, _ := mecab.ParseToNode("こんにちは世界"); !node.IsZero(); node = node.Next() {
 			node.Surface()
 		}
 	}

--- a/model.go
+++ b/model.go
@@ -79,6 +79,7 @@ func NewModel(args map[string]string) (Model, error) {
 
 // Destroy frees the model.
 func (m Model) Destroy() {
+	runtime.SetFinalizer(m.m, nil) // clear the finalizer
 	C.mecab_model_destroy(m.m.model)
 	m.m.model = nil
 }

--- a/model_test.go
+++ b/model_test.go
@@ -1,6 +1,7 @@
 package mecab
 
 import (
+	"runtime"
 	"strings"
 	"testing"
 )
@@ -44,4 +45,13 @@ func TestNewModel_error(t *testing.T) {
 	if !strings.Contains(err.Error(), "unknown format type [unknown format]") {
 		t.Errorf("want %q error, got %q", "unknown format type [unknown format]", err.Error())
 	}
+}
+
+func TestModelFinalizer(t *testing.T) {
+	for i := 0; i < 10000; i++ {
+		NewModel(rcfile(map[string]string{}))
+	}
+	runtime.GC()
+	runtime.GC()
+	runtime.GC()
 }

--- a/node.go
+++ b/node.go
@@ -22,16 +22,16 @@ const (
 	NormalNode NodeStat = 0
 
 	// UnknownNode is status for unknown node.
-	UnknownNode = 1
+	UnknownNode NodeStat = 1
 
 	// BOSNode is status for BOS(Begin Of Sentence) node.
-	BOSNode = 2
+	BOSNode NodeStat = 2
 
 	// EOSNode is status for EOS(End Of Sentence) node.
-	EOSNode = 3
+	EOSNode NodeStat = 3
 
 	// EONNode is status for EON(End Of Node) node.
-	EONNode = 4
+	EONNode NodeStat = 4
 )
 
 func (stat NodeStat) String() string {


### PR DESCRIPTION
After Destroy is called, the finalizer is no longer needed.