### PR TITLE
Add PosID() Function for Retrieving MeCab's POS ID

### DIFF
--- a/node.go
+++ b/node.go
@@ -75,6 +75,11 @@ func (node Node) RLength() int {
 	return int(node.node.rlength)
 }
 
+// PosID returns the part-of-speech id.
+func (node Node) PosID() int {
+	return int(node.node.posid)
+}
+
 // Prev returns the previous Node.
 func (node Node) Prev() Node {
 	return Node{node: (*C.mecab_node_t)(node.node.prev)}


### PR DESCRIPTION
Dear shogo82148,

I hope this message finds you well. I am writing to propose a new feature for the `go-mecab` library, which I believe will enhance its functionality.

**Feature Description:**
The feature I've implemented is the `PosID()` function, which enables users to retrieve the Part-of-Speech (POS) ID from MeCab. This addition will provide developers with more flexibility and utility when working with MeCab in Go, especially for those dealing with advanced linguistic processing tasks.

**Implementation Details:**
- The `PosID()` function accesses MeCab's internal POS ID for each token.
- It returns the POS ID as an integer.

Thank you for considering my contribution. I look forward to your feedback.

Best regards,
kmurata08