### PR TITLE
add Go 1.22 to the build matrix

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,7 +15,8 @@ jobs:
     strategy:
       matrix:
         go:
-          - "1"
+          - "stable"
+          - "1.22"
           - "1.21"
           - "1.20"
       fail-fast: false
@@ -45,7 +46,8 @@ jobs:
     strategy:
       matrix:
         go:
-          - "1"
+          - "stable"
+          - "1.22"
           - "1.21"
           - "1.20"
       fail-fast: false
@@ -75,7 +77,8 @@ jobs:
     strategy:
       matrix:
         go:
-          - "1"
+          - "stable"
+          - "1.22"
           - "1.21"
           - "1.20"
       fail-fast: false


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit


- **Chores**
	- Updated Go versions in CI workflow to include "stable" and "1.22" alongside existing versions.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->